### PR TITLE
Install gnome.adwaita-icon-theme

### DIFF
--- a/applications.nix
+++ b/applications.nix
@@ -10,6 +10,7 @@
     libreoffice
     openscad
     prusa-slicer
+    gnome.adwaita-icon-theme
     (callPackage applications/visicut.nix { })
     yakuake
   ];


### PR DESCRIPTION
This fixes an issue with Inkscape missing some icons