### PR TITLE
Restrict auto updater to run only once per boot

### DIFF
--- a/autoupdate.nix
+++ b/autoupdate.nix
@@ -5,9 +5,11 @@
     description = "FabLab AutoUpdater";
     wantedBy = [ "multi-user.target" ];
     script = ''
+      if [ -f /autoupdate-finished ]; then exit 0; fi
       rm -rf /etc/nixos
       git clone --depth=1 https://github.com/FabLab-Altmuehlfranken/NixOS-Workstation.git /etc/nixos
       nixos-rebuild boot --upgrade
+      touch /autoupdate-finished
     '';
     serviceConfig = {
       Type = "oneshot";


### PR DESCRIPTION
This prevents the deletion (and re-download) of `/etc/nixos` after running `nixos-rebuild switch`

Related to #12