### PR TITLE
Avoid updating homedir while user is logged in

### DIFF
--- a/homedir.nix
+++ b/homedir.nix
@@ -3,7 +3,7 @@
     source = ./home;
   };
   system.activationScripts.script.text = ''
-    if [[ $(who | grep fablab) > 0 ]]; then echo logged in; fi
+    if [[ $(who | grep fablab) > 0 ]]; then exit 0; fi
     cp -r /etc/fablab/ /home
     chown -R fablab:users /home/fablab
     chmod -R u+w /home/fablab

--- a/homedir.nix
+++ b/homedir.nix
@@ -3,6 +3,7 @@
     source = ./home;
   };
   system.activationScripts.script.text = ''
+    if [[ $(who | grep fablab) > 0 ]]; then echo logged in; fi
     cp -r /etc/fablab/ /home
     chown -R fablab:users /home/fablab
     chmod -R u+w /home/fablab


### PR DESCRIPTION
This prevents some bugs, like Firefox crashing due to overwriting the profile.

Usually, we change the profile directly, anyway, so updating it isn't necessary.

In case we do want to update the profile, logging out the current user (and running `nixos-rebuild switch` directly as root) will update the home dir nevertheless.

Related to #12