### PR TITLE
Use mirrored VisiCut build to prevent download errors

### DIFF
--- a/applications/visicut.nix
+++ b/applications/visicut.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.9-205-gd98e82d0";
 
   src = fetchzip {
-    url = "https://download.visicut.org/files/master/All/${pname}-${version}.zip";
+    url = "https://mirror.lewd.wtf/archive/visicut/${pname}-${version}.zip";
     sha256 = "sha256-0PoQVx3Gs4yUsMMgBKUwQSE8Jw4d/fDqFd5MQv64fn4=";
   };
 


### PR DESCRIPTION
Today, I had massive issues downloading VisiCut from the official servers, causing rebuilds to fail a lot of times.

As the official download server seems to be having those issues frequently, I've mirrored the current download to one of my servers, so that we can prevent build failures.

Just a suggestion, feel free to close / propose alternatives.