### PR TITLE
Shutdown when current boot seems to be scheduled

### DIFF
--- a/autoupdate.nix
+++ b/autoupdate.nix
@@ -11,6 +11,7 @@
       git clone --depth=1 https://github.com/FabLab-Altmuehlfranken/NixOS-Workstation.git /etc/nixos
       nixos-rebuild boot --flake '/etc/nixos#fablab'
       touch /autoupdate-finished
+      if [ $(TZ=UTC date +%H) = 3 ]; then shutdown -hP now; fi
     '';
     serviceConfig = {
       Type = "oneshot";


### PR DESCRIPTION
The idea is to configure our machines to automatically boot at 3 am UTC to fetch any pending updates.
That way we can avoid workstations that are out of date.