### PR TITLE
Fix failing autoupdates

### DIFF
--- a/autoupdate.nix
+++ b/autoupdate.nix
@@ -7,7 +7,7 @@
     wantedBy = [ "multi-user.target" ];
     script = ''
       if [ -f /autoupdate-finished ]; then exit 0; fi
-      TZ=UTC rtcwake --date "$(date -d "tomorrow 3am" "+%Y-%m-%d %H:%M")"
+      TZ=UTC rtcwake --date "$(date -d "tomorrow 3am" "+%Y-%m-%d %H:%M")" ||:
       nix-collect-garbage --delete-older-than 30d
       rm -rf /etc/nixos
       git clone --depth=1 https://github.com/FabLab-Altmuehlfranken/NixOS-Workstation.git /etc/nixos


### PR DESCRIPTION
The rtcwake command returns 1 on our system. Nixos adds -e to the script which will end further execution when one command failes. This change makes sure the script executes further if the rtcwake command has issues.