### PR TITLE
Revert "Fix inkcut missing setuptools package"

### DIFF
--- a/applications.nix
+++ b/applications.nix
@@ -13,26 +13,6 @@
     (callPackage applications/visicut.nix { })
     yakuake
   ];
-  nixpkgs.overlays = [
-    (
-      final: prev: {
-        inkcut = prev.inkcut.overridePythonAttrs {
-          propagatedBuildInputs = with pkgs.python3.pkgs; [
-            enamlx
-            twisted
-            lxml
-            qreactor
-            jsonpickle
-            pyserial
-            pycups
-            qtconsole
-            pyqt5
-            setuptools
-          ];
-        };
-      }
-    )
-  ];
 
   virtualisation.docker.enable = true;
 }


### PR DESCRIPTION
Reverts FabLab-Altmuehlfranken/NixOS-Workstation#43

No longer necessary as soon as the contents of NixOS/nixpkgs#287547 are available in nixos-unstable.