### PR TITLE
Ensure local nix channels follow Flake inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,12 +12,17 @@
           system.configurationRevision = nixpkgs.lib.mkIf (self ? rev) self.rev;
           _module.args = { inherit inkstitch; };
 
+          systemd.tmpfiles.rules = [
+            "L+ /nix/nixPath - - - - ${pkgs.path}"
+          ];
+
           nix = {
             package = pkgs.nixFlakes;
             extraOptions = ''
               experimental-features = nix-command flakes
             '';
             registry.nixpkgs.flake = nixpkgs;
+            nixPath = [ "nixpkgs=/nix/nixPath" ];
 
             settings = {
               substituters = [


### PR DESCRIPTION
This ensures that "legacy" nix tools (like for example `nix-shell`) use the currently pinned Flake input for `nixpkgs` as their channel.

Closes #45 