### PR TITLE
Add network share as native mount

### DIFF
--- a/hardware-configuration.nix
+++ b/hardware-configuration.nix
@@ -4,29 +4,29 @@
 { config, lib, pkgs, modulesPath, ... }:
 
 {
-  imports =
-    [ (modulesPath + "/installer/scan/not-detected.nix")
-    ];
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
 
   boot.initrd.availableKernelModules = [ "xhci_pci" "ehci_pci" "ahci" "usbhid" "usb_storage" "virtio_pci" "virtio_scsi" "sd_mod" "sr_mod" ];
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ "kvm-intel" ];
   boot.extraModulePackages = [ ];
 
-  fileSystems."/" =
-    { device = "/dev/disk/by-label/root";
-      fsType = "ext4";
-    };
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/root";
+    fsType = "ext4";
+  };
 
-  fileSystems."/boot" =
-   { device = "/dev/disk/by-label/boot";
-      fsType = "vfat";
-    };
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/boot";
+    fsType = "vfat";
+  };
 
-  fileSystems."/nix" =
-    { device = "/dev/disk/by-label/nixstore";
-      fsType = "ext4";
-    };
+  fileSystems."/nix" = {
+    device = "/dev/disk/by-label/nixstore";
+    fsType = "ext4";
+  };
 
   fileSystems."/home/fablab/Desktop/Netzlaufwerk" = {
     device = "omv.fablab.local:/desktop";
@@ -34,9 +34,9 @@
     options = [ "nfsvers=4.2" "x-systemd.automount" "noauto" ];
   };
 
-  swapDevices =
-    [ { device = "/dev/disk/by-label/swap"; }
-    ];
+  swapDevices = [
+    { device = "/dev/disk/by-label/swap"; }
+  ];
 
   # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
   # (the default) this is the recommended approach. When using systemd-networkd it's

--- a/hardware-configuration.nix
+++ b/hardware-configuration.nix
@@ -28,6 +28,12 @@
       fsType = "ext4";
     };
 
+  fileSystems."/home/fablab/Desktop/Netzlaufwerk" = {
+    device = "omv.fablab.local:/desktop";
+    fsType = "nfs";
+    options = [ "nfsvers=4.2" "x-systemd.automount" "noauto" ];
+  };
+
   swapDevices =
     [ { device = "/dev/disk/by-label/swap"; }
     ];

--- a/hardware-configuration.nix
+++ b/hardware-configuration.nix
@@ -29,7 +29,7 @@
   };
 
   fileSystems."/home/fablab/Desktop/Netzlaufwerk" = {
-    device = "omv.fablab.local:/desktop";
+    device = "omv.fablab.local:/public";
     fsType = "nfs";
     options = [ "nfsvers=4.2" "x-systemd.automount" "noauto" ];
   };

--- a/home/Desktop/Netzlaufwerk
+++ b/home/Desktop/Netzlaufwerk
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Charset=
-Icon=folder-remote
-Name=Netzlaufwerk
-Type=Link
-URL=smb://omv.fablab.local/public


### PR DESCRIPTION
Based on the setup of my gaming rig. Using systemd automounts instead of native nfs in order to avoid issues in case the share is offline.

Closes #51 