### PR TITLE
Use nixos-24.05 as 24.11 uses incompatible Python ver

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1700306973,
-        "narHash": "sha256-etBFt8+37Q3f9oP1mqElb+mim+Yd/wUZGn0YguTkH9E=",
+        "lastModified": 1720735582,
+        "narHash": "sha256-IECjrYTdXgkSIbFYdCPBbF1+eYdyszRQ2Cmyz/jiR0Q=",
         "owner": "FabLab-Altmuehlfranken",
         "repo": "nix-inkstitch",
-        "rev": "fbc624ab0833096f9cd32bcb322d262ecd60e25a",
+        "rev": "4418ccfca5f7afc0f6e99cb1e3653f30b7f2852a",
         "type": "github"
       },
       "original": {
@@ -38,32 +38,32 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700204040,
-        "narHash": "sha256-xSVcS5HBYnD3LTer7Y2K8ZQCDCXMa3QUD1MzRjHzuhI=",
+        "lastModified": 1720553833,
+        "narHash": "sha256-IXMiHQMtdShDXcBW95ctA+m5Oq2kLxnBt7WlMxvDQXA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c757e9bd77b16ca2e03c89bf8bc9ecb28e0c06ad",
+        "rev": "249fbde2a178a2ea2638b65b9ecebd531b338cf9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1720031269,
-        "narHash": "sha256-rwz8NJZV+387rnWpTYcXaRNvzUSnnF9aHONoJIYmiUQ=",
+        "lastModified": 1720553833,
+        "narHash": "sha256-IXMiHQMtdShDXcBW95ctA+m5Oq2kLxnBt7WlMxvDQXA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
+        "rev": "249fbde2a178a2ea2638b65b9ecebd531b338cf9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs = { url = "github:nixos/nixpkgs/nixos-unstable"; };
+    nixpkgs = { url = "github:nixos/nixpkgs/nixos-24.05"; };
     inkstitch = { url = "github:FabLab-Altmuehlfranken/nix-inkstitch/master"; };
   };
 


### PR DESCRIPTION
24.11 (which is being prepared in unstable) switches to Python 3.12, which is currently incompatible with wxpython 4.2.1 (used by Ink/Stitch), as well as shiboken2 (used by FreeCAD).

Noticed this today while trying to update one host in order to debug Nvidia GPU shenanigans.