### PR TITLE
Switch back to nixos-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1727540905,
-        "narHash": "sha256-40J9tW7Y794J7Uw4GwcAKlMxlX2xISBl6IBigo83ih8=",
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fbca5e745367ae7632731639de5c21f29c8744ed",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs = { url = "github:nixos/nixpkgs/nixos-24.05"; };
+    nixpkgs = { url = "github:nixos/nixpkgs/nixos-unstable"; };
     inkstitch = { url = "github:FabLab-Altmuehlfranken/nix-inkstitch/master"; };
   };
 


### PR DESCRIPTION
This is necessary to get the latest PrusaSlicer.
The Python issues preventing the use of 24.11 / unstable have been resolved by now.